### PR TITLE
some improvements (speed, plugin.zsh, fallback if fzf is not installed)

### DIFF
--- a/zsh-fzf-history-search.plugin.zsh
+++ b/zsh-fzf-history-search.plugin.zsh
@@ -1,0 +1,2 @@
+0=${(%):-%N}
+source ${0:A:h}/zsh-fzf-history-search.zsh

--- a/zsh-fzf-history-search.zsh
+++ b/zsh-fzf-history-search.zsh
@@ -1,4 +1,7 @@
-fzf_history_seach() {
+# do nothing if fzf is not installed
+(( ! $+commands[fzf] )) && return
+
+fzf_history_search() {
   setopt extendedglob
   candidates=(${(f)"$(fc -li -1 0 | fzf +s +m -x -e -q "$BUFFER")"})
   BUFFER="${candidates[@]/(#m)*/${${(As: :)MATCH}[4,-1]}}"
@@ -7,7 +10,7 @@ fzf_history_seach() {
   zle end-of-buffer-or-history
 }
 
-autoload fzf_history_seach
-zle -N fzf_history_seach
+autoload fzf_history_search
+zle -N fzf_history_search
 
-bindkey '^r' fzf_history_seach
+bindkey '^r' fzf_history_search

--- a/zsh-fzf-history-search.zsh
+++ b/zsh-fzf-history-search.zsh
@@ -1,6 +1,6 @@
 fzf_history_seach() {
   setopt extendedglob
-  candidates=(${(f)"$(history -t '%Y-%m-%d %H:%M:%S' 0| fzf +s +m -x --tac -e -q "$BUFFER")"})
+  candidates=(${(f)"$(fc -li -1 0 | fzf +s +m -x -e -q "$BUFFER")"})
   BUFFER="${candidates[@]/(#m)*/${${(As: :)MATCH}[4,-1]}}"
   BUFFER="${BUFFER[@]/(#b)(?)\\n/$match[1]
 }"


### PR DESCRIPTION
I changed the code to use the `fc` command directly instead of the `history` alias. Furthermore the reverse sort will be done directly in `fc` so that `fzf` won't scroll on large histories