### PR TITLE
Don't include event numbers in search

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ plugins=(… zsh-fzf-history-search)
 | `ZSH_FZF_HISTORY_SEARCH_FZF_ARGS`         | Arguments for `fzf` (might be updated, not recommended to override) (default: `'+s +m -x -e'`)    |
 | `ZSH_FZF_HISTORY_SEARCH_FZF_EXTRA_ARGS`   | Extra arguments for `fzf` (default: `''`)                                                         |
 | `ZSH_FZF_HISTORY_SEARCH_END_OF_LINE`      | Put the cursor on at the end of the line after completion, `empty=false` (default: `''`)          |
+| `ZSH_FZF_HISTORY_SEARCH_EVENT_NUMBERS`    | Include event numbers in search.  Set to 0 to remove event numbers from the search. (default: `1`)|
 
 
 ## TODO

--- a/zsh-fzf-history-search.zsh
+++ b/zsh-fzf-history-search.zsh
@@ -17,12 +17,25 @@ typeset -g ZSH_FZF_HISTORY_SEARCH_FZF_EXTRA_ARGS=''
 (( ! ${+ZSH_FZF_HISTORY_SEARCH_END_OF_LINE} )) &&
 typeset -g ZSH_FZF_HISTORY_SEARCH_END_OF_LINE=''
 
+# Include event numbers
+(( ! ${+ZSH_FZF_HISTORY_SEARCH_EVENT_NUMBERS} )) &&
+typeset -g ZSH_FZF_HISTORY_SEARCH_EVENT_NUMBERS=1
+
 fzf_history_search() {
   setopt extendedglob
-  candidates=(${(f)"$(fc -li -1 0 | fzf ${=ZSH_FZF_HISTORY_SEARCH_FZF_ARGS} ${=ZSH_FZF_HISTORY_SEARCH_FZF_EXTRA_ARGS} -q "$BUFFER")"})
+
+  FC_ARGS="-li"
+  CANDIDATE_LEADING_FIELDS=4
+
+  if (( ! $ZSH_FZF_HISTORY_SEARCH_EVENT_NUMBERS )); then
+    FC_ARGS+=" -n"
+    CANDIDATE_LEADING_FIELDS=3
+  fi
+
+  candidates=(${(f)"$(fc ${=FC_ARGS} -1 0 | fzf ${=ZSH_FZF_HISTORY_SEARCH_FZF_ARGS} ${=ZSH_FZF_HISTORY_SEARCH_FZF_EXTRA_ARGS} -q "$BUFFER")"})
   local ret=$?
   if [ -n "$candidates" ]; then
-    BUFFER="${candidates[@]/(#m)*/${${(As: :)MATCH}[4,-1]}}"
+    BUFFER="${candidates[@]/(#m)*/${${(As: :)MATCH}[${CANDIDATE_LEADING_FIELDS},-1]}}"
     BUFFER="${BUFFER[@]/(#b)(?)\\n/$match[1]
 }"
     zle vi-fetch-history -n $BUFFER

--- a/zsh-fzf-history-search.zsh
+++ b/zsh-fzf-history-search.zsh
@@ -19,7 +19,7 @@ typeset -g ZSH_FZF_HISTORY_SEARCH_END_OF_LINE=''
 
 fzf_history_search() {
   setopt extendedglob
-  candidates=(${(f)"$(fc -li -1 0 | fzf $(echo $ZSH_FZF_HISTORY_SEARCH_FZF_ARGS) $(echo $ZSH_FZF_HISTORY_SEARCH_FZF_EXTRA_ARGS) -q "$BUFFER")"})
+  candidates=(${(f)"$(fc -li -1 0 | fzf ${=ZSH_FZF_HISTORY_SEARCH_FZF_ARGS} ${=ZSH_FZF_HISTORY_SEARCH_FZF_EXTRA_ARGS} -q "$BUFFER")"})
   local ret=$?
   if [ -n "$candidates" ]; then
     BUFFER="${candidates[@]/(#m)*/${${(As: :)MATCH}[4,-1]}}"


### PR DESCRIPTION
Event numbers don't add information to the search: if you knew the
event number you wouldn't be searching for the command.  Remove them
from the search to declutter it.