### PR TITLE
Fix handling of whitespaces and line breaks

### DIFF
--- a/zsh-fzf-history-search.zsh
+++ b/zsh-fzf-history-search.zsh
@@ -64,8 +64,7 @@ fzf_history_search() {
     else
       BUFFER="${candidates[@]}"
     fi
-    BUFFER="${BUFFER[@]/(#b)(?)\\n/$match[1]
-}"
+    BUFFER=$(printf "${BUFFER[@]//\\\\n/\\\\\\n}")
     zle vi-fetch-history -n $BUFFER
     if [ -n "${ZSH_FZF_HISTORY_SEARCH_END_OF_LINE}" ]; then
       zle end-of-line

--- a/zsh-fzf-history-search.zsh
+++ b/zsh-fzf-history-search.zsh
@@ -59,7 +59,11 @@ fzf_history_search() {
   candidates=(${(f)"$(eval $history_cmd | fzf ${=ZSH_FZF_HISTORY_SEARCH_FZF_ARGS} ${=ZSH_FZF_HISTORY_SEARCH_FZF_EXTRA_ARGS} -q "$BUFFER")"})
   local ret=$?
   if [ -n "$candidates" ]; then
-    BUFFER="${candidates[@]/(#m)*/${${(As: :)MATCH}[${CANDIDATE_LEADING_FIELDS},-1]}}"
+    if (( ! $CANDIDATE_LEADING_FIELDS == 1 )); then
+      BUFFER="${candidates[@]/(#m)[0-9 \-\:]##/${${(As: :)MATCH}[${CANDIDATE_LEADING_FIELDS},-1]}}"
+    else
+      BUFFER="${candidates[@]}"
+    fi
     BUFFER="${BUFFER[@]/(#b)(?)\\n/$match[1]
 }"
     zle vi-fetch-history -n $BUFFER


### PR DESCRIPTION
This PR fixes the issue of removing repeated white spaces. The previous expansion condensed repeated white-spaces such as modifying `echo "foo    bar"` to `echo "foo bar"`.

Additionally, this PR ensures that line breaks are now handled correctly, enabling support for multi-line history.
- before
  ![screenshot_2023-02-11_04-48-06](https://user-images.githubusercontent.com/42025957/218184781-44eaf8e9-7411-4458-9f4d-68be9b7b84ac.png)
- after
  ![screenshot_2023-02-11_04-49-31](https://user-images.githubusercontent.com/42025957/218184772-1c7bf235-6df3-45e0-9ede-995e3a48c15c.png)

