### PR TITLE
Ability to define a fzf query prefix which is only used when $BUFFER is not empty.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Zgenom will automatically clone the plugin repositories for you when you do a `z
 | `ZSH_FZF_HISTORY_SEARCH_BIND`             | `'^r'`                                  | Keybind to trigger fzf reverse search                                                                      |
 | `ZSH_FZF_HISTORY_SEARCH_FZF_ARGS`         | `'+s +m -x -e --preview-window=hidden'` | Arguments for `fzf` (might be updated, not recommended to override)                                        |
 | `ZSH_FZF_HISTORY_SEARCH_FZF_EXTRA_ARGS`   | `''`                                    | Extra arguments for `fzf`                                                                                  |
+| `ZSH_FZF_HISTORY_SEARCH_FZF_QUERY_PREFIX` | `''`                                    | Query prefix for `fzf` when $BUFFER is not empty. Set it to '^' to query history lines begin with $BUFFER  |
 | `ZSH_FZF_HISTORY_SEARCH_END_OF_LINE`      | `''`                                    | Put the cursor on at the end of the line after completion, `empty=false`                                   |
 | `ZSH_FZF_HISTORY_SEARCH_EVENT_NUMBERS`    | `1`                                     | Include event numbers in search.  Set to 0 to remove event numbers from the search.                        |
 | `ZSH_FZF_HISTORY_SEARCH_DATES_IN_SEARCH`  | `1`                                     | Include ISO8601 timestamps in search.  Set to 0 to remove them from the search.                            |


### PR DESCRIPTION
When $BUFFER is not empty this allows to set a prefix for the fzf query to limit results to only lines beginning with the content of $BUFFER:

`ZSH_FZF_HISTORY_SEARCH_FZF_QUERY_PREFIX='^' # Prefix Query with ^`


My complete zsh-fzf-history-search configuration:
```
ZSH_FZF_HISTORY_SEARCH_BIND='^[[1;5A' # Ctrl-Up
ZSH_FZF_HISTORY_SEARCH_DATES_IN_SEARCH=0 # No dates
ZSH_FZF_HISTORY_SEARCH_EVENT_NUMBERS=0 # No event numbers
ZSH_FZF_HISTORY_SEARCH_REMOVE_DUPLICATES=1 # Remove duplicates
ZSH_FZF_HISTORY_SEARCH_END_OF_LINE=1 # Place cursor at the end of the line
ZSH_FZF_HISTORY_SEARCH_FZF_QUERY_PREFIX='^' # Prefix Query with ^
ZSH_FZF_HISTORY_SEARCH_FZF_EXTRA_ARGS='--multi' # Allow multiple selections
```