### PR TITLE
fix arithmetic operation again

### DIFF
--- a/zsh-fzf-history-search.zsh
+++ b/zsh-fzf-history-search.zsh
@@ -68,7 +68,7 @@ fzf_history_search() {
 
   local ret=$?
   if [ -n "$candidates" ]; then
-    if (( ! $CANDIDATE_LEADING_FIELDS == 1 )); then
+    if (( $CANDIDATE_LEADING_FIELDS != 1 )); then
       BUFFER="${candidates[@]/(#m)[0-9 \-\:]##/$(
       printf '%s' "${${(As: :)MATCH}[${CANDIDATE_LEADING_FIELDS},-1]}" | sed 's/%/%%/g'
       )}"


### PR DESCRIPTION
- It appears that fix in #28 has been undone by commit d5a9730b5b4cb0b39959f7f1044f9c52743832ba.
  - This affects the behavior when `ZSH_FZF_HISTORY_SEARCH_EVENT_NUMBERS` is set to `0` and `ZSH_FZF_HISTORY_SEARCH_DATES_IN_SEARCH` is set to `1` simultaneously.
  - When you select a command and press `Enter`, not only the command but also the datetime are entered (See the images below).
- This PR solves the problem again.

![image](https://github.com/joshskidmore/zsh-fzf-history-search/assets/57034105/420162a4-4b32-439c-b8a2-4065c296892e)

![image](https://github.com/joshskidmore/zsh-fzf-history-search/assets/57034105/3c82460b-86e8-4a60-8846-8c005ced15f7)


