### PR TITLE
Accommodate history line number with asterisk

### DIFF
--- a/zsh-fzf-history-search.zsh
+++ b/zsh-fzf-history-search.zsh
@@ -69,7 +69,7 @@ fzf_history_search() {
   local ret=$?
   if [ -n "$candidates" ]; then
     if (( $CANDIDATE_LEADING_FIELDS != 1 )); then
-      BUFFER="${candidates[@]/(#m)[0-9 \-\:]##/$(
+      BUFFER="${candidates[@]/(#m)[0-9 \-\:\*]##/$(
       printf '%s' "${${(As: :)MATCH}[${CANDIDATE_LEADING_FIELDS},-1]}" | sed 's/%/%%/g'
       )}"
     else


### PR DESCRIPTION
## Problem
Hey there! I noticed that when `HIST_EXTENDED` is enabled, in-memory history entries (i.e. those not yet written to the history file) are marked with an asterisk `*` after the event number. For example:

```
  2961* 2025-11-02 17:23  ls -la ~/.config/nvim
  2962  2025-11-02 17:25  gs
```

When selecting entry `2961*` in fzf, the plugin would incorrectly include the timestamp in the command buffer, resulting in:
```
2025-11-02 17:23  ls -la ~/.config/nvim
```

Instead of just:
```
ls -la ~/.config/nvim
```

The issue I found was in the regex pattern used to strip leading fields (event numbers and timestamps). The pattern `[0-9 \-\:]##` matched digits, spaces, hyphens, and colons, but not asterisks.

## Changes
* Add `\*` to the character class so the pattern becomes `[0-9 \-\:\*]##`, which now correctly strips asterisks along with event numbers and timestamps.

## Testing
I didn't test a ton, but I have `HIST_EXTENDED=true` and `SHARE_HISTORY=true`, and was able to autocomplete both in-memory and persisted history entries.

Lemme know if you have any questions or requests, and thank you for this plugin!
