### PR TITLE
Add ability to immediately execute cmd instead of needing to press enter a second time

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ and run `sheldon lock` to install the plugin.
 | `ZSH_FZF_HISTORY_SEARCH_EVENT_NUMBERS`    | `1`                                     | Include event numbers in search.  Set to 0 to remove event numbers from the search.                        |
 | `ZSH_FZF_HISTORY_SEARCH_DATES_IN_SEARCH`  | `1`                                     | Include ISO8601 timestamps in search.  Set to 0 to remove them from the search.                            |
 | `ZSH_FZF_HISTORY_SEARCH_REMOVE_DUPLICATES`| `''`                                    | Remove duplicate entries from search.  Only makes sense with `EVENT_NUMBERS` and `DATE_INSEARCH` 0 (false).|
+| `ZSH_FZF_HISTORY_SEARCH_FZF_ACCEPT_ENTER` | `0`                                     | Execute the selected line instead of just putting it on the prompt.                                        |
+| `ZSH_FZF_HISTORY_SEARCH_FZF_EDIT_KEY`.    | `'left'`                                | If ZSH_FZF_HISTORY_SEARCH_FZF_ACCEPT_ENTER=1 then this key will put the selected line on the prompt.       |
 
 
 ## TODO

--- a/zsh-fzf-history-search.zsh
+++ b/zsh-fzf-history-search.zsh
@@ -39,7 +39,7 @@ typeset -g ZSH_FZF_HISTORY_SEARCH_FZF_ACCEPT_ENTER=0
 
 # Define fzf edit item key
 (( ! ${+ZSH_FZF_HISTORY_SEARCH_FZF_EDIT_KEY} )) &&
-typeset -g ZSH_FZF_HISTORY_SEARCH_FZF_EDIT_KEY='left'
+typeset -g ZSH_FZF_HISTORY_SEARCH_FZF_EDIT_KEY='right'
 
 fzf_history_search() {
   setopt extendedglob

--- a/zsh-fzf-history-search.zsh
+++ b/zsh-fzf-history-search.zsh
@@ -33,6 +33,14 @@ typeset -g ZSH_FZF_HISTORY_SEARCH_REMOVE_DUPLICATES=''
 (( ! ${+ZSH_FZF_HISTORY_SEARCH_FZF_QUERY_PREFIX} )) &&
 typeset -g ZSH_FZF_HISTORY_SEARCH_FZF_QUERY_PREFIX=''
 
+# Define fzf accept on enter
+(( ! ${+ZSH_FZF_HISTORY_SEARCH_FZF_ACCEPT_ENTER} )) &&
+typeset -g ZSH_FZF_HISTORY_SEARCH_FZF_ACCEPT_ENTER=0
+
+# Define fzf edit item key
+(( ! ${+ZSH_FZF_HISTORY_SEARCH_FZF_EDIT_KEY} )) &&
+typeset -g ZSH_FZF_HISTORY_SEARCH_FZF_EDIT_KEY='left'
+
 fzf_history_search() {
   setopt extendedglob
 
@@ -60,10 +68,37 @@ fzf_history_search() {
     fi
   fi
 
+  local accept_args=""
+  if (( $ZSH_FZF_HISTORY_SEARCH_FZF_ACCEPT_ENTER )); then
+    accept_args="--expect=${ZSH_FZF_HISTORY_SEARCH_FZF_EDIT_KEY}"
+    # ZSH_FZF_HISTORY_SEARCH_FZF_ARGS+=" --bind '${=ZSH_FZF_HISTORY_SEARCH_FZF_EDIT_KEY}:become(echo +{})' "
+  fi
+
+  # printf '%s\n' "fzf ${=ZSH_FZF_HISTORY_SEARCH_FZF_ARGS} ${=ZSH_FZF_HISTORY_SEARCH_FZF_EXTRA_ARGS}" >/tmp/mike
+
   if (( $#BUFFER )); then
-    candidates=(${(f)"$(eval $history_cmd | fzf ${=ZSH_FZF_HISTORY_SEARCH_FZF_ARGS} ${=ZSH_FZF_HISTORY_SEARCH_FZF_EXTRA_ARGS} -q "${=ZSH_FZF_HISTORY_SEARCH_FZF_QUERY_PREFIX}$BUFFER")"})
+    candidates=(${(f)"$(eval $history_cmd | fzf ${=accept_args} ${=ZSH_FZF_HISTORY_SEARCH_FZF_ARGS} ${=ZSH_FZF_HISTORY_SEARCH_FZF_EXTRA_ARGS} -q "${=ZSH_FZF_HISTORY_SEARCH_FZF_QUERY_PREFIX}$BUFFER")"})
   else
-    candidates=(${(f)"$(eval $history_cmd | fzf ${=ZSH_FZF_HISTORY_SEARCH_FZF_ARGS} ${=ZSH_FZF_HISTORY_SEARCH_FZF_EXTRA_ARGS})"})
+    candidates=(${(f)"$(eval $history_cmd | fzf ${=accept_args} ${=ZSH_FZF_HISTORY_SEARCH_FZF_ARGS} ${=ZSH_FZF_HISTORY_SEARCH_FZF_EXTRA_ARGS})"})
+  fi
+
+  local accept=${ZSH_FZF_HISTORY_SEARCH_FZF_ACCEPT_ENTER}
+  if (( $ZSH_FZF_HISTORY_SEARCH_FZF_ACCEPT_ENTER )); then
+    # save IFS
+    local saved_IFS=${IFS}
+    # split the candidates into lines
+    IFS=$'\n' out=("${candidates}")
+    # first line is the key pressed to exit fzf
+    key=$(head -1 <<< "$out")
+    # second line is the actual candidates
+    candidates=$(head -2 <<< "$out" | tail -1)
+    # check if the edit key was pressed
+    if [ "$key" = "${ZSH_FZF_HISTORY_SEARCH_FZF_EDIT_KEY}" ]; then
+      # set accept to 0 to avoid accepting the line
+      accept=0
+    fi
+    # restore IFS
+    IFS=${saved_IFS}
   fi
 
   local ret=$?
@@ -82,6 +117,12 @@ fzf_history_search() {
   fi
 
   zle reset-prompt
+
+  # if accept is set to 1 then accept(execute) the line
+  if [ $accept -eq 1 ]; then
+    zle accept-line
+  fi
+
   return $ret
 }
 


### PR DESCRIPTION
This was a quality of life improvement for me. I hated having to hit enter twice but still needed to edit the cmd. Added ability to immediately execute the selected history item on 'enter' and maintained ability to edit history item.

`ZSH_FZF_HISTORY_SEARCH_FZF_ACCEPT_ENTER=0`
`ZSH_FZF_HISTORY_SEARCH_FZF_EDIT_KEY='right'`

By setting `ZSH_FZF_HISTORY_SEARCH_FZF_ACCEPT_ENTER=1` it will add `--expect=ZSH_FZF_HISTORY_SEARCH_FZF_EDIT_KEY ` to the fzf command. When `enter` or `ZSH_FZF_HISTORY_SEARCH_FZF_EDIT_KEY` is pressed the return value is 2 lines with the first one being the key that was used to exit fzf. 

End result of setting 1 and left in addition to EOL=1. This now functions closer to stock history but in a much prettier format I think. 

Using this in connection with `ZSH_FZF_HISTORY_SEARCH_END_OF_LINE` such that `EOL=1` then `EDIT_KEY=left` would make more sense.